### PR TITLE
WIP: 优化路线统计逻辑，更新数据库索引

### DIFF
--- a/api/dashboard/stats/route.go
+++ b/api/dashboard/stats/route.go
@@ -144,13 +144,6 @@ func (r *RouteApi) Run(ctx *gin.Context) kit.Code {
 		})
 	}
 
-	// 转换为累计经过人数：例如原始(0,1)会返回为(1,1)。
-	totalPassed := 0
-	for i := len(r.Response.PointStats) - 1; i >= 0; i-- {
-		totalPassed += r.Response.PointStats[i].PassedCount
-		r.Response.PointStats[i].PassedCount = totalPassed
-	}
-
 	statusRows, err := routeRepo.ListSingleRouteStatusCounts(ctx, routeName)
 	if err != nil {
 		nlog.Pick().WithContext(ctx).WithError(err).Error("查询路线状态统计失败")

--- a/dao/cache/route/route.go
+++ b/dao/cache/route/route.go
@@ -14,22 +14,22 @@ import (
 )
 
 const (
-	routeCacheKeyPrefix       = "walk:route"
-	routeCacheTTL			 = time.Hour
-	routeEdgeCacheKeyPrefix   = "walk:route_edge"
-	routeEdgeCacheTTL		=time.Hour	
-	pointRoutesCacheKeyPrefix = "walk:point:routes"
-	pointRoutesCacheTTL         = time.Hour
-	allRouteStatsCacheKey         = "dashboard:stats:route:all"
-	allRouteStatsCacheTTL         = 15 * time.Second
-	overviewCacheKeyPrefix        = "dashboard:overview"
-	overviewCacheTTL              = 15 * time.Second
-	segmentCacheKeyPrefix         = "dashboard:segment"
-	segmentCacheTTL               = 15 * time.Second
-	checkpointCacheKeyPrefix      = "dashboard:checkpoint"
-	checkpointCacheTTL            = 15 * time.Second
+	routeCacheKeyPrefix            = "walk:route"
+	routeCacheTTL                  = time.Hour
+	routeEdgeCacheKeyPrefix        = "walk:route_edge"
+	routeEdgeCacheTTL              = time.Hour
+	pointRoutesCacheKeyPrefix      = "walk:point:routes"
+	pointRoutesCacheTTL            = time.Hour
+	allRouteStatsCacheKey          = "dashboard:stats:route:all"
+	allRouteStatsCacheTTL          = 15 * time.Second
+	overviewCacheKeyPrefix         = "dashboard:overview"
+	overviewCacheTTL               = 15 * time.Second
+	segmentCacheKeyPrefix          = "dashboard:segment"
+	segmentCacheTTL                = 15 * time.Second
+	checkpointCacheKeyPrefix       = "dashboard:checkpoint"
+	checkpointCacheTTL             = 15 * time.Second
 	routeDetailStatsCacheKeyPrefix = "dashboard:stats:route:detail"
-	routeDetailStatsCacheTTL      = 15 * time.Second
+	routeDetailStatsCacheTTL       = 15 * time.Second
 )
 
 func client() redis.UniversalClient {

--- a/dao/repo/route.go
+++ b/dao/repo/route.go
@@ -197,18 +197,49 @@ func (r *RouteRepo) ListRoutePoints(ctx context.Context, routeName string) ([]Ro
 	return rows, nil
 }
 
-// ListRoutePointPassedCounts 查询各点位经过人数（按 people 口径）。
+// ListRoutePointPassedCounts 查询各点位累计到达人数（按 people 口径）。
+// 统计逻辑：
+// 1) 先找每队最后一次有效打卡点位，映射为该队已到达的 reached_seq。
+// 2) 在同一 route_name 内，累计 reached_seq >= 点位 seq_order 的队伍人数。
+// 注意：seq_order 只在同一 route_name 下比较；不同路线存在相同 seq_order 不影响结果。
 func (r *RouteRepo) ListRoutePointPassedCounts(ctx context.Context, routeName string) ([]PointPassedCountRow, error) {
 	rows := make([]PointPassedCountRow, 0)
 
 	err := r.query.Checkin.WithContext(ctx).
 		UnderlyingDB().
 		Raw(
-			"SELECT cp.point_name, COUNT(ps.id) AS cnt "+
-				"FROM (SELECT DISTINCT team_id, point_name FROM checkins WHERE route_name = ? AND point_name IS NOT NULL AND point_name <> '') AS cp "+
-				"JOIN teams AS t ON t.id = cp.team_id AND t.submit = 1 AND t.route_name = ? "+
-				"JOIN peoples AS ps ON ps.team_id = t.id "+
-				"GROUP BY cp.point_name",
+			"WITH latest_checkin AS ("+
+				"SELECT c.team_id, c.point_name "+
+				"FROM checkins AS c "+
+				"JOIN ("+
+				"SELECT team_id, MAX(id) AS max_id "+
+				"FROM checkins "+
+				"WHERE route_name = ? AND point_name IS NOT NULL AND point_name <> '' "+
+				"GROUP BY team_id"+
+				") AS x ON x.max_id = c.id "+
+				"), route_point_seq AS ("+
+				"SELECT point_name, MIN(seq_order) AS seq_order "+
+				"FROM route_edges "+
+				"WHERE route_name = ? AND point_name IS NOT NULL AND point_name <> '' "+
+				"GROUP BY point_name"+
+				"), team_reached AS ("+
+				"SELECT t.id AS team_id, rps.seq_order AS reached_seq "+
+				"FROM teams AS t "+
+				"JOIN latest_checkin AS lc ON lc.team_id = t.id "+
+				"JOIN route_point_seq AS rps ON rps.point_name = lc.point_name "+
+				"WHERE t.submit = 1 AND t.route_name = ?"+
+				"), team_people AS ("+
+				"SELECT tr.team_id, tr.reached_seq, COUNT(ps.id) AS people_count "+
+				"FROM team_reached AS tr "+
+				"JOIN peoples AS ps ON ps.team_id = tr.team_id "+
+				"GROUP BY tr.team_id, tr.reached_seq"+
+				") "+
+				"SELECT rp.point_name, COALESCE(SUM(tp.people_count), 0) AS cnt "+
+				"FROM route_point_seq AS rp "+
+				"LEFT JOIN team_people AS tp ON tp.reached_seq >= rp.seq_order "+
+				"GROUP BY rp.point_name "+
+				"ORDER BY MIN(rp.seq_order) ASC, rp.point_name ASC",
+			routeName,
 			routeName,
 			routeName,
 		).

--- a/dao/repo/route.go
+++ b/dao/repo/route.go
@@ -199,7 +199,7 @@ func (r *RouteRepo) ListRoutePoints(ctx context.Context, routeName string) ([]Ro
 
 // ListRoutePointPassedCounts 查询各点位累计到达人数（按 people 口径）。
 // 统计逻辑：
-// 1) 先找每队最后一次有效打卡点位，映射为该队已到达的 reached_seq。
+// 1) 先按队伍在该路线内的最大 seq_order 计算 reached_seq，避免回扫/补扫导致进度回退。
 // 2) 先按 reached_seq 聚合 people_count，再用窗口函数做累计和。
 // 注意：seq_order 只在同一 route_name 下比较；不同路线存在相同 seq_order 不影响结果。
 func (r *RouteRepo) ListRoutePointPassedCounts(ctx context.Context, routeName string) ([]PointPassedCountRow, error) {
@@ -208,26 +208,18 @@ func (r *RouteRepo) ListRoutePointPassedCounts(ctx context.Context, routeName st
 	err := r.query.Checkin.WithContext(ctx).
 		UnderlyingDB().
 		Raw(
-			"WITH latest_checkin AS ("+
-				"SELECT c.team_id, c.point_name "+
-				"FROM checkins AS c "+
-				"JOIN ("+
-				"SELECT team_id, MAX(id) AS max_id "+
-				"FROM checkins "+
-				"WHERE route_name = ? AND point_name IS NOT NULL AND point_name <> '' "+
-				"GROUP BY team_id"+
-				") AS x ON x.max_id = c.id "+
-				"), route_point_seq AS ("+
+			"WITH route_point_seq AS ("+
 				"SELECT point_name, MIN(seq_order) AS seq_order "+
 				"FROM route_edges "+
 				"WHERE route_name = ? AND point_name IS NOT NULL AND point_name <> '' "+
 				"GROUP BY point_name"+
 				"), team_reached AS ("+
-				"SELECT t.id AS team_id, rps.seq_order AS reached_seq "+
+				"SELECT t.id AS team_id, MAX(rps.seq_order) AS reached_seq "+
 				"FROM teams AS t "+
-				"JOIN latest_checkin AS lc ON lc.team_id = t.id "+
-				"JOIN route_point_seq AS rps ON rps.point_name = lc.point_name "+
-				"WHERE t.submit = 1 AND t.route_name = ?"+
+				"JOIN checkins AS c ON c.team_id = t.id AND c.route_name = ? AND c.point_name IS NOT NULL AND c.point_name <> '' "+
+				"JOIN route_point_seq AS rps ON rps.point_name = c.point_name "+
+				"WHERE t.submit = 1 AND t.route_name = ? "+
+				"GROUP BY t.id"+
 				"), team_people_by_seq AS ("+
 				"SELECT tr.reached_seq, COUNT(ps.id) AS people_count "+
 				"FROM team_reached AS tr "+

--- a/dao/repo/route.go
+++ b/dao/repo/route.go
@@ -200,7 +200,7 @@ func (r *RouteRepo) ListRoutePoints(ctx context.Context, routeName string) ([]Ro
 // ListRoutePointPassedCounts 查询各点位累计到达人数（按 people 口径）。
 // 统计逻辑：
 // 1) 先找每队最后一次有效打卡点位，映射为该队已到达的 reached_seq。
-// 2) 在同一 route_name 内，累计 reached_seq >= 点位 seq_order 的队伍人数。
+// 2) 先按 reached_seq 聚合 people_count，再用窗口函数做累计和。
 // 注意：seq_order 只在同一 route_name 下比较；不同路线存在相同 seq_order 不影响结果。
 func (r *RouteRepo) ListRoutePointPassedCounts(ctx context.Context, routeName string) ([]PointPassedCountRow, error) {
 	rows := make([]PointPassedCountRow, 0)
@@ -228,17 +228,24 @@ func (r *RouteRepo) ListRoutePointPassedCounts(ctx context.Context, routeName st
 				"JOIN latest_checkin AS lc ON lc.team_id = t.id "+
 				"JOIN route_point_seq AS rps ON rps.point_name = lc.point_name "+
 				"WHERE t.submit = 1 AND t.route_name = ?"+
-				"), team_people AS ("+
-				"SELECT tr.team_id, tr.reached_seq, COUNT(ps.id) AS people_count "+
+				"), team_people_by_seq AS ("+
+				"SELECT tr.reached_seq, COUNT(ps.id) AS people_count "+
 				"FROM team_reached AS tr "+
 				"JOIN peoples AS ps ON ps.team_id = tr.team_id "+
-				"GROUP BY tr.team_id, tr.reached_seq"+
+				"GROUP BY tr.reached_seq"+
+				"), seq_levels AS ("+
+				"SELECT DISTINCT seq_order FROM route_point_seq"+
+				"), seq_cumulative AS ("+
+				"SELECT sl.seq_order, COALESCE(SUM(COALESCE(tps.people_count, 0)) OVER ("+
+				"ORDER BY sl.seq_order DESC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"+
+				"), 0) AS cnt "+
+				"FROM seq_levels AS sl "+
+				"LEFT JOIN team_people_by_seq AS tps ON tps.reached_seq = sl.seq_order"+
 				") "+
-				"SELECT rp.point_name, COALESCE(SUM(tp.people_count), 0) AS cnt "+
+				"SELECT rp.point_name, sc.cnt "+
 				"FROM route_point_seq AS rp "+
-				"LEFT JOIN team_people AS tp ON tp.reached_seq >= rp.seq_order "+
-				"GROUP BY rp.point_name "+
-				"ORDER BY MIN(rp.seq_order) ASC, rp.point_name ASC",
+				"JOIN seq_cumulative AS sc ON sc.seq_order = rp.seq_order "+
+				"ORDER BY rp.seq_order ASC, rp.point_name ASC",
 			routeName,
 			routeName,
 			routeName,

--- a/deploy/sql/checkins.sql
+++ b/deploy/sql/checkins.sql
@@ -9,5 +9,6 @@ CREATE TABLE `checkins` (
   `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
   PRIMARY KEY (`id`),
   KEY `idx_checkins_route_point` (`route_name`, `point_name`),
+  KEY `idx_checkins_route_team_id` (`route_name`, `team_id`, `id`),
   KEY `idx_checkins_time` (`time`)
 );

--- a/deploy/sql/route_edge.sql
+++ b/deploy/sql/route_edge.sql
@@ -7,5 +7,6 @@ CREATE TABLE `route_edges` (
   `updated_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
   `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
   PRIMARY KEY (`id`),
-  KEY `idx_route_edges_points` (`prev_point_name`, `point_name`)
+  KEY `idx_route_edges_points` (`prev_point_name`, `point_name`),
+  KEY `idx_route_edges_route_point_seq` (`route_name`, `point_name`, `seq_order`)
 );


### PR DESCRIPTION
This pull request refactors the way cumulative participant counts are calculated and queried for route points, improving both the accuracy and efficiency of the statistics. The main changes include a significant rewrite of the SQL logic for counting participants, removal of redundant in-memory accumulation logic, and the addition of new database indexes to optimize query performance.

**Database and Query Logic Improvements:**

* Rewrote the SQL query in `ListRoutePointPassedCounts` (`dao/repo/route.go`) to calculate cumulative participant counts per route point directly in the database. The new logic:
  - Determines each team's last valid check-in,
  - Maps it to the corresponding route sequence,
  - Aggregates the number of people per team who have reached at least each point,
  - Ensures accurate cumulative counts even for overlapping sequence orders across different routes.
* Removed the redundant in-memory accumulation of `PassedCount` in the API handler (`api/dashboard/stats/route.go`), as the database query now returns already-cumulative values.

**Database Indexing Enhancements:**

* Added a composite index on `route_name`, `team_id`, and `id` to the `checkins` table to speed up queries for the latest check-in per team. (`deploy/sql/checkins.sql`)
* Added a composite index on `route_name`, `point_name`, and `seq_order` to the `route_edges` table to optimize lookups for route point sequences. (`deploy/sql/route_edge.sql`)